### PR TITLE
#39 - Trending Searches

### DIFF
--- a/app/Http/Controllers/HistoryController.php
+++ b/app/Http/Controllers/HistoryController.php
@@ -35,6 +35,7 @@ class HistoryController extends Controller {
                 $grouped_searches[strtolower($search->query)] = 1;
             }
         }
+        arsort($grouped_searches);
         return $grouped_searches;
     }
 }

--- a/app/Http/Controllers/HistoryController.php
+++ b/app/Http/Controllers/HistoryController.php
@@ -21,10 +21,20 @@ class HistoryController extends Controller {
             return $this->api_response('Please supply query history ID', 400);
         }
         SearchHistory::delete_query_history(Request::get('id'));
+        return $this->api_response('Success', 200);
     }
 
     public function get_trending_searches() {
-
-
+        $searches = SearchHistory::get_trending_searches();
+        $grouped_searches = [];
+        foreach ($searches as $search) {
+            if (array_key_exists(strtolower($search->query), $grouped_searches)) {
+                $grouped_searches[strtolower($search->query)]++;
+            }
+            else {
+                $grouped_searches[strtolower($search->query)] += 1;
+            }
+        }
+        return $grouped_searches;
     }
 }

--- a/app/Http/Controllers/HistoryController.php
+++ b/app/Http/Controllers/HistoryController.php
@@ -24,7 +24,7 @@ class HistoryController extends Controller {
         return $this->api_response('Success', 200);
     }
 
-    public function get_trending_searches() {
+    public static function get_trending_searches() {
         $searches = SearchHistory::get_trending_searches();
         $grouped_searches = [];
         foreach ($searches as $search) {
@@ -32,7 +32,7 @@ class HistoryController extends Controller {
                 $grouped_searches[strtolower($search->query)]++;
             }
             else {
-                $grouped_searches[strtolower($search->query)] += 1;
+                $grouped_searches[strtolower($search->query)] = 1;
             }
         }
         return $grouped_searches;

--- a/app/Http/Controllers/HistoryController.php
+++ b/app/Http/Controllers/HistoryController.php
@@ -22,4 +22,9 @@ class HistoryController extends Controller {
         }
         SearchHistory::delete_query_history(Request::get('id'));
     }
+
+    public function get_trending_searches() {
+
+
+    }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 
 namespace App\Http\Controllers;
+use App\Http\Controllers\HistoryController;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Auth;
@@ -16,7 +17,10 @@ class HomeController extends Controller {
      */
     public function home() {
         return view('home.layout', [
-           'isMobile' => $this->agent->isMobile()
+           'isMobile' => $this->agent->isMobile(),
+           'trending' => HistoryController::get_trending_searches(),
+            'entry_count' => 0
+
         ]);
     }
 

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -19,9 +19,11 @@ class SearchController extends Controller {
             return view('home.layout');
         }
 
-        if (Auth::user()) {
-            SearchHistory::record_user_search(Request::get('s'), Auth::user()->id);
-        }
+        SearchHistory::record_user_search(
+            Request::get('s'),
+            Auth::user() ? Auth::user()->id : -1
+        );
+
         return view('search.layout', [
             'results' => $this->get_search_results(
                 Request::get('s')

--- a/app/SearchHistory.php
+++ b/app/SearchHistory.php
@@ -74,5 +74,13 @@ class SearchHistory extends Model
         ]);
     }
 
+    public static function get_trending_searches() {
+        return DB::table(self::TABLE_NAME)->where(
+            'date',
+            '>=',
+            date('Y-m-d H:i:s', strtotime('-1 week'))
+        )->get();
+    }
+
 
 }

--- a/public/css/home/main.css
+++ b/public/css/home/main.css
@@ -211,7 +211,6 @@ a {
     border-radius: 20px;
     height: 100px;
     margin: 50px auto 0px;
-    padding-top: 90px;
     text-align: center;
 }
 
@@ -225,4 +224,18 @@ a {
     height: 175px;
     position: relative;
     float: left;
+}
+
+#trending {
+    width: 100%;
+    height: 100%;
+    border-collapse: unset;
+}
+
+th {
+
+    border: solid 1px black;
+}
+td {
+    border: solid 1px black;
 }

--- a/public/css/home/main.css
+++ b/public/css/home/main.css
@@ -207,10 +207,9 @@ a {
 
 #about-home {
     background-color: #eeeeee;
-    border: 1px solid #d1d1d1;
     border-radius: 20px;
     height: 100px;
-    margin: 50px auto 0px;
+    margin: 70px auto 0px;
     text-align: center;
 }
 
@@ -230,12 +229,21 @@ a {
     width: 100%;
     height: 100%;
     border-collapse: unset;
+    box-shadow: 0 0 20px #4de5cc;
+    border: solid 1px black;
+    border-radius:6px;
+    -moz-border-radius:6px;
+    background: white;
 }
-
+td, th {
+    border-left:solid black 1px;
+    border-top:solid black 1px;
+}
 th {
-
-    border: solid 1px black;
+    border-top: none;
+    height: 28px;
 }
-td {
-    border: solid 1px black;
+
+td:first-child, th:first-child {
+    border-left: none;
 }

--- a/resources/views/home/components/main_search.blade.php
+++ b/resources/views/home/components/main_search.blade.php
@@ -24,15 +24,21 @@
                 <table id="trending" class="table table-striped table-bordered">
                     <thead>
                     <tr>
-                        <th scope="col" class="col-md-1">#</th>
+                        <th scope="col" class="col-md-1">Total</th>
                         <th scope="col" class="col-md-1">Trending Searches</th>
                     </tr>
                     </thead>
                     <tbody>
-                    <tr data-seq="1">
-                        <td class="td_row_text">1</td>
-                        <td class="td_row_text">Query</td>
-                    </tr>
+                    @foreach ($trending as $query => $count)
+                        <tr data-seq="1">
+                            <td class="td_row_text">{{$count}}</td>
+                            <td class="td_row_text">{{$query}}</td>
+                        </tr>
+                        @if ($entry_count++ & $entry_count > 5)
+                            @break
+                        @endif
+
+                    @endforeach
                     </tbody>
                 </table>
             </div>

--- a/resources/views/home/components/main_search.blade.php
+++ b/resources/views/home/components/main_search.blade.php
@@ -21,9 +21,21 @@
         <!-- Optional info bar - Can't make this fit on mobile -->
         @if (!($isMobile ?? ''))
             <div id="about-home">
-                <span id="about-home-text">Powered by Machine Learning</span>
+                <table id="trending" class="table table-striped table-bordered">
+                    <thead>
+                    <tr>
+                        <th scope="col" class="col-md-1">#</th>
+                        <th scope="col" class="col-md-1">Trending Searches</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr data-seq="1">
+                        <td class="td_row_text">1</td>
+                        <td class="td_row_text">Query</td>
+                    </tr>
+                    </tbody>
+                </table>
             </div>
-            <img id="powered-by" src="{{asset('img/aibrain.png')}}">
         @endif
     </div>
 </div>


### PR DESCRIPTION
Implements a 'trending searches' API and has a basic display for this on the home page. The table orders the queries by total times the search term has been queried and is case insensitive. 


Basic demo
![trending](https://user-images.githubusercontent.com/36802059/110002360-24594400-7cca-11eb-856e-d528e41f265e.gif)

Bubbling 'hi' to the top of the queries
![trending2](https://user-images.githubusercontent.com/36802059/110002378-27eccb00-7cca-11eb-9743-9d98d8a1ba3a.gif)
